### PR TITLE
Separate prompt formatting from context usage display

### DIFF
--- a/app/src/main/java/com/bloodtailor/myllmapp/MainActivity.kt
+++ b/app/src/main/java/com/bloodtailor/myllmapp/MainActivity.kt
@@ -147,7 +147,7 @@ class MainActivity : ComponentActivity() {
                         }
                     }
 
-                    // Prompt input with formatted preview
+                    // Prompt input with raw prompt preview and context usage
                     PromptInput(
                         prompt = prompt,
                         onPromptChanged = { prompt = it },
@@ -158,11 +158,10 @@ class MainActivity : ComponentActivity() {
                         onFormattedPromptUpdated = { localFormattedPrompt = it }
                     )
 
-                    // Send button
+                    // Send button - simplified to always send raw prompts
                     SendButton(
                         viewModel = viewModel,
-                        prompt = prompt,
-                        useFormattedPrompt = showFormattedPrompt
+                        prompt = prompt
                     )
 
                     // Response display - ensure this is in a layout that supports weight


### PR DESCRIPTION
The prompt was automatically being formatted and the context usage could only be updated along with the automatic basic prompt formatting. 

The prompt is no longer automatically formatted.

Functionality to format the prompt should be added later to give user more control over the exact formatting.