### PR TITLE
Feature/persist text on rotate

### DIFF
--- a/app/src/main/java/com/bloodtailor/myllmapp/MainActivity.kt
+++ b/app/src/main/java/com/bloodtailor/myllmapp/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -44,15 +45,15 @@ class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     fun LLMAppUI() {
-        // Local UI state
-        var prompt by remember { mutableStateOf("") }
-        var showFormattedPrompt by remember { mutableStateOf(false) }
-        var localFormattedPrompt by remember { mutableStateOf("") }
-        var showSettingsDialog by remember { mutableStateOf(false) }
-        var showModelDialog by remember { mutableStateOf(false) }
-        var showSettingsOnStart by remember { mutableStateOf(true) }
-        var showFullScreenInput by remember { mutableStateOf(false) }
-        var showFullScreenResponse by remember { mutableStateOf(false) }
+        // UI state that persists across screen rotations
+        var prompt by rememberSaveable { mutableStateOf("") }
+        var showFormattedPrompt by rememberSaveable { mutableStateOf(false) }
+        var localFormattedPrompt by rememberSaveable { mutableStateOf("") }
+        var showSettingsDialog by rememberSaveable { mutableStateOf(false) }
+        var showModelDialog by rememberSaveable { mutableStateOf(false) }
+        var showSettingsOnStart by rememberSaveable { mutableStateOf(true) }
+        var showFullScreenInput by rememberSaveable { mutableStateOf(false) }
+        var showFullScreenResponse by rememberSaveable { mutableStateOf(false) }
 
         // Add connection status state
         val connectionStatus = remember {

--- a/app/src/main/java/com/bloodtailor/myllmapp/ui/UiComponents.kt
+++ b/app/src/main/java/com/bloodtailor/myllmapp/ui/UiComponents.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.Send
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -62,8 +63,8 @@ fun FullScreenPromptEditor(
         onClose()
     }
 
-    // Text field state for cursor management - preserve cursor position
-    var textFieldValue by remember {
+    // Text field state for cursor management - preserve cursor position across rotations
+    var textFieldValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {
         mutableStateOf(TextFieldValue(prompt, TextRange(prompt.length)))
     }
 
@@ -239,7 +240,7 @@ fun ModelSelector(
     enabled: Boolean,
     onModelSelected: (String) -> Unit
 ) {
-    var expanded by remember { mutableStateOf(false) }
+    var expanded by rememberSaveable { mutableStateOf(false) }
 
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -681,7 +682,7 @@ fun SettingsDialog(
     onDismiss: () -> Unit,
     onSave: (String) -> Unit
 ) {
-    var tempServerUrl by remember { mutableStateOf(currentServerUrl) }
+    var tempServerUrl by rememberSaveable { mutableStateOf(currentServerUrl) }
 
     LaunchedEffect(currentServerUrl, showDialog) {
         if (showDialog) {
@@ -739,10 +740,10 @@ fun ModelSettingsDialog(
     viewModel: LlmViewModel,
     onDismiss: () -> Unit
 ) {
-    // State variables
-    var selectedModel by remember { mutableStateOf("") }
-    var contextLengthInput by remember { mutableStateOf("") }
-    var expanded by remember { mutableStateOf(false) } // Add this for the dropdown
+    // State variables with rotation persistence
+    var selectedModel by rememberSaveable { mutableStateOf("") }
+    var contextLengthInput by rememberSaveable { mutableStateOf("") }
+    var expanded by rememberSaveable { mutableStateOf(false) }
 
     // Update selectedModel when viewModel values change
     LaunchedEffect(viewModel.availableModels, viewModel.currentModel, showDialog) {

--- a/app/src/main/java/com/bloodtailor/myllmapp/viewmodel/LlmViewModel.kt
+++ b/app/src/main/java/com/bloodtailor/myllmapp/viewmodel/LlmViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.bloodtailor.myllmapp.data.LlmRepository
 import kotlinx.coroutines.launch
@@ -15,33 +16,65 @@ import com.bloodtailor.myllmapp.network.ContextUsage
 
 
 /**
- * ViewModel for managing LLM-related state and operations
+ * ViewModel for managing LLM-related state and operations with screen rotation persistence
  */
-class LlmViewModel(application: Application) : AndroidViewModel(application) {
+class LlmViewModel(
+    application: Application,
+    private val savedStateHandle: SavedStateHandle
+) : AndroidViewModel(application) {
+
+    // Keys for saved state
+    private companion object {
+        const val SERVER_URL_KEY = "server_url"
+        const val CURRENT_MODEL_KEY = "current_model"
+        const val CURRENT_CONTEXT_LENGTH_KEY = "current_context_length"
+        const val MODEL_LOADED_KEY = "model_loaded"
+        const val STATUS_MESSAGE_KEY = "status_message"
+        const val LLM_RESPONSE_KEY = "llm_response"
+    }
 
     // Repository for data operations
     private val repository = LlmRepository(application, "")
 
-    // Server state
-    var serverUrl by mutableStateOf(repository.getServerUrl())
+    // Server state with persistence
+    var serverUrl by mutableStateOf(
+        savedStateHandle.get<String>(SERVER_URL_KEY) ?: repository.getServerUrl()
+    )
         private set
 
-    // Model state
+    // Model state with persistence
     var availableModels = mutableStateListOf<String>()
         private set
-    var currentModelLoaded by mutableStateOf(false)
-        private set
-    var currentModel by mutableStateOf<String?>(null)
-        private set
-    var currentContextLength by mutableStateOf<Int?>(null)
+
+    var currentModelLoaded by mutableStateOf(
+        savedStateHandle.get<Boolean>(MODEL_LOADED_KEY) ?: false
+    )
         private set
 
-    // UI state
+    var currentModel by mutableStateOf(
+        savedStateHandle.get<String?>(CURRENT_MODEL_KEY)
+    )
+        private set
+
+    var currentContextLength by mutableStateOf(
+        savedStateHandle.get<Int?>(CURRENT_CONTEXT_LENGTH_KEY)
+    )
+        private set
+
+    // UI state with persistence
     var isLoading by mutableStateOf(false)
         private set
-    var statusMessage by mutableStateOf("Please configure server address in settings")
+
+    var statusMessage by mutableStateOf(
+        savedStateHandle.get<String>(STATUS_MESSAGE_KEY)
+            ?: "Please configure server address in settings"
+    )
         private set
-    var llmResponse by mutableStateOf("Response will appear here...")
+
+    var llmResponse by mutableStateOf(
+        savedStateHandle.get<String>(LLM_RESPONSE_KEY)
+            ?: "Response will appear here..."
+    )
         private set
 
     // Default values
@@ -51,10 +84,24 @@ class LlmViewModel(application: Application) : AndroidViewModel(application) {
     var contextUsage by mutableStateOf<ContextUsage?>(null)
         private set
 
-
     init {
-        // Initialize with current server URL but don't fetch models automatically
-        updateServerUrl(repository.getServerUrl(), autoConnect = false)
+        // Don't call updateServerUrl here - let MainActivity handle initialization
+        // This prevents auto-connecting during state restoration
+
+        // Save initial state
+        saveState()
+    }
+
+    /**
+     * Save current state to handle
+     */
+    private fun saveState() {
+        savedStateHandle[SERVER_URL_KEY] = serverUrl
+        savedStateHandle[CURRENT_MODEL_KEY] = currentModel
+        savedStateHandle[CURRENT_CONTEXT_LENGTH_KEY] = currentContextLength
+        savedStateHandle[MODEL_LOADED_KEY] = currentModelLoaded
+        savedStateHandle[STATUS_MESSAGE_KEY] = statusMessage
+        savedStateHandle[LLM_RESPONSE_KEY] = llmResponse
     }
 
     // Update this method to include an autoConnect parameter
@@ -62,12 +109,16 @@ class LlmViewModel(application: Application) : AndroidViewModel(application) {
         repository.updateServerUrl(url)
         serverUrl = url
 
+        // Save to savedStateHandle for rotation persistence
+        savedStateHandle[SERVER_URL_KEY] = url
+
         // Add logging
         android.util.Log.d("LlmViewModel", "Server URL updated to: $url")
 
         // Only refresh data if autoConnect is true
         if (autoConnect) {
             statusMessage = "Connecting to server..."
+            savedStateHandle[STATUS_MESSAGE_KEY] = statusMessage
             fetchAvailableModels()
             checkModelStatus()
         }
@@ -80,6 +131,7 @@ class LlmViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch {
             isLoading = true
             statusMessage = "Loading models..."
+            savedStateHandle[STATUS_MESSAGE_KEY] = statusMessage
 
             repository.getAvailableModels().fold(
                 onSuccess = { models ->
@@ -93,9 +145,11 @@ class LlmViewModel(application: Application) : AndroidViewModel(application) {
                         statusMessage = "${models.size} models loaded"
                         android.util.Log.d("LlmViewModel", "Models loaded: ${models.joinToString()}")
                     }
+                    savedStateHandle[STATUS_MESSAGE_KEY] = statusMessage
                 },
                 onFailure = { error ->
                     statusMessage = "Error loading models: ${error.message}"
+                    savedStateHandle[STATUS_MESSAGE_KEY] = statusMessage
                     android.util.Log.e("LlmViewModel", "Error loading models", error)
                 }
             )
@@ -115,15 +169,22 @@ class LlmViewModel(application: Application) : AndroidViewModel(application) {
                     currentModel = status.currentModel
                     currentContextLength = status.contextLength
 
+                    // Save state
+                    savedStateHandle[MODEL_LOADED_KEY] = currentModelLoaded
+                    savedStateHandle[CURRENT_MODEL_KEY] = currentModel
+                    savedStateHandle[CURRENT_CONTEXT_LENGTH_KEY] = currentContextLength
+
                     // Clear status message if connected
                     if (statusMessage == "Please configure server address in settings" ||
                         statusMessage == "Connecting to server...") {
                         statusMessage = ""
+                        savedStateHandle[STATUS_MESSAGE_KEY] = statusMessage
                     }
                 },
                 onFailure = { error ->
                     android.util.Log.e("LlmViewModel", "Error checking model status", error)
                     statusMessage = "Error checking model status: ${error.message}"
+                    savedStateHandle[STATUS_MESSAGE_KEY] = statusMessage
                 }
             )
         }
@@ -136,6 +197,7 @@ class LlmViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch {
             isLoading = true
             statusMessage = "Loading model..."
+            savedStateHandle[STATUS_MESSAGE_KEY] = statusMessage
 
             repository.loadModel(modelName, contextLength).fold(
                 onSuccess = { result ->
@@ -143,10 +205,18 @@ class LlmViewModel(application: Application) : AndroidViewModel(application) {
                     currentModel = modelName
                     currentContextLength = result.contextLength
                     statusMessage = result.message
+
+                    // Save state
+                    savedStateHandle[MODEL_LOADED_KEY] = currentModelLoaded
+                    savedStateHandle[CURRENT_MODEL_KEY] = currentModel
+                    savedStateHandle[CURRENT_CONTEXT_LENGTH_KEY] = currentContextLength
+                    savedStateHandle[STATUS_MESSAGE_KEY] = statusMessage
+
                     onComplete?.invoke(true)
                 },
                 onFailure = { error ->
                     statusMessage = "Error: ${error.message}"
+                    savedStateHandle[STATUS_MESSAGE_KEY] = statusMessage
                     onComplete?.invoke(false)
                 }
             )
@@ -162,6 +232,7 @@ class LlmViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch {
             isLoading = true
             statusMessage = "Unloading model..."
+            savedStateHandle[STATUS_MESSAGE_KEY] = statusMessage
 
             repository.unloadModel().fold(
                 onSuccess = { message ->
@@ -170,10 +241,18 @@ class LlmViewModel(application: Application) : AndroidViewModel(application) {
                     currentContextLength = null
                     statusMessage = message
                     contextUsage = null  // Clear context usage when unloading
+
+                    // Save state
+                    savedStateHandle[MODEL_LOADED_KEY] = currentModelLoaded
+                    savedStateHandle[CURRENT_MODEL_KEY] = currentModel
+                    savedStateHandle[CURRENT_CONTEXT_LENGTH_KEY] = currentContextLength
+                    savedStateHandle[STATUS_MESSAGE_KEY] = statusMessage
+
                     onComplete?.invoke(true)
                 },
                 onFailure = { error ->
                     statusMessage = "Error: ${error.message}"
+                    savedStateHandle[STATUS_MESSAGE_KEY] = statusMessage
                     onComplete?.invoke(false)
                 }
             )
@@ -217,11 +296,13 @@ class LlmViewModel(application: Application) : AndroidViewModel(application) {
     ) {
         if (!currentModelLoaded || currentModel == null) {
             statusMessage = "Please load a model first"
+            savedStateHandle[STATUS_MESSAGE_KEY] = statusMessage
             return
         }
 
         isLoading = true
         llmResponse = "Generating response..."
+        savedStateHandle[LLM_RESPONSE_KEY] = llmResponse
 
         // Send the raw prompt exactly as typed by the user
         repository.sendStreamingPrompt(
@@ -231,8 +312,14 @@ class LlmViewModel(application: Application) : AndroidViewModel(application) {
         ) { status, content ->
             viewModelScope.launch(Dispatchers.Main) {
                 when (status) {
-                    "generating", "complete" -> llmResponse = content
-                    "error" -> llmResponse = "Error: $content"
+                    "generating", "complete" -> {
+                        llmResponse = content
+                        savedStateHandle[LLM_RESPONSE_KEY] = llmResponse
+                    }
+                    "error" -> {
+                        llmResponse = "Error: $content"
+                        savedStateHandle[LLM_RESPONSE_KEY] = llmResponse
+                    }
                 }
 
                 if (status == "complete" || status == "error") {
@@ -247,6 +334,7 @@ class LlmViewModel(application: Application) : AndroidViewModel(application) {
      */
     fun clearResponse() {
         llmResponse = "Response will appear here..."
+        savedStateHandle[LLM_RESPONSE_KEY] = llmResponse
     }
 
     /**
@@ -254,5 +342,6 @@ class LlmViewModel(application: Application) : AndroidViewModel(application) {
      */
     fun clearStatusMessage() {
         statusMessage = ""
+        savedStateHandle[STATUS_MESSAGE_KEY] = statusMessage
     }
 }

--- a/app/src/main/java/com/bloodtailor/myllmapp/viewmodel/LlmViewModelFactory.kt
+++ b/app/src/main/java/com/bloodtailor/myllmapp/viewmodel/LlmViewModelFactory.kt
@@ -1,0 +1,28 @@
+package com.bloodtailor.myllmapp.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AbstractSavedStateViewModelFactory
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.savedstate.SavedStateRegistryOwner
+
+/**
+ * Factory for creating LlmViewModel with SavedStateHandle support
+ */
+class LlmViewModelFactory(
+    private val application: Application,
+    owner: SavedStateRegistryOwner
+) : AbstractSavedStateViewModelFactory(owner, null) {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(
+        key: String,
+        modelClass: Class<T>,
+        handle: SavedStateHandle
+    ): T {
+        if (modelClass.isAssignableFrom(LlmViewModel::class.java)) {
+            return LlmViewModel(application, handle) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}


### PR DESCRIPTION
There was an issue where whenever you rotate the screen, all the text would get removed and and the server url would revert back to default. 

Replaced all remember with rememberSaveable for UI state.

FullScreenPromptEditor: Updated to use rememberSaveable(stateSaver = TextFieldValue.Saver) for the text field state.